### PR TITLE
:construction_worker: add lint

### DIFF
--- a/.github/workflows/lint-hosting.yaml
+++ b/.github/workflows/lint-hosting.yaml
@@ -1,4 +1,4 @@
-name: build-hosting
+name: lint-hosting
 on:
   pull_request:
     branches: [ master ]


### PR DESCRIPTION
# WHY
ref. #34 
コードをきれいに保ち隊 👷 

# WHAT
`npm run lint` を行う

## おねがい
~~[このリンク](https://stackoverflow.com/questions/58654530/how-to-reject-a-pull-request-if-tests-are-failed-github-actions) を参考に `build`, `lint` が通らないとマージできない設定にしてほしいです:bow:~~
すでにされていたかも？