### PR TITLE
Fix/#39 alert use component

### DIFF
--- a/hosting/src/components/Header.tsx
+++ b/hosting/src/components/Header.tsx
@@ -76,6 +76,7 @@ class Header extends React.Component<unknown, State> {
           onClose={this.onSnackClose}
           anchorOrigin={{ vertical: 'top', horizontal: 'right' }}
           severnity={this.state.snackSeverity}
+          variant="filled"
         >
           {this.state.copyResultMsg}
         </Notification>

--- a/hosting/src/components/Header.tsx
+++ b/hosting/src/components/Header.tsx
@@ -9,6 +9,7 @@ import {
 } from '@material-ui/core';
 import { Alert } from '@material-ui/lab';
 import { Share } from '@material-ui/icons';
+import Notification from './Notification';
 import Spacer from './Spacer';
 import { copyText } from '../utils/util';
 import classes from './Header.module.css';
@@ -39,11 +40,13 @@ class Header extends React.Component<unknown, State> {
       this.setState({
         copySnackOpen: true,
         snackSeverity: 'success',
+        copyResultMsg: 'Copied URL!',
       });
     } catch (e) {
       this.setState({
         copySnackOpen: true,
         snackSeverity: 'error',
+        copyResultMsg: 'Failed copy.',
       });
     }
   }
@@ -67,16 +70,15 @@ class Header extends React.Component<unknown, State> {
           </IconButton>
         </Toolbar>
 
-        <Snackbar
+        <Notification
           open={this.state.copySnackOpen}
           autoHideDuration={2000}
           onClose={this.onSnackClose}
           anchorOrigin={{ vertical: 'top', horizontal: 'right' }}
+          severnity={this.state.snackSeverity}
         >
-          <Alert onClose={this.onSnackClose} severity={this.state.snackSeverity}>
-            {this.state.copyResultMsg}
-          </Alert>
-        </Snackbar>
+          {this.state.copyResultMsg}
+        </Notification>
       </AppBar>
     );
   }

--- a/hosting/src/components/Header.tsx
+++ b/hosting/src/components/Header.tsx
@@ -5,9 +5,7 @@ import {
   Toolbar,
   Typography,
   IconButton,
-  Snackbar,
 } from '@material-ui/core';
-import { Alert } from '@material-ui/lab';
 import { Share } from '@material-ui/icons';
 import Notification from './Notification';
 import Spacer from './Spacer';

--- a/hosting/src/components/Notification.tsx
+++ b/hosting/src/components/Notification.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import { Snackbar } from '@material-ui/core';
+import { Alert } from '@material-ui/lab';
+
+type AlertType = 'error' | 'warning' | 'info' | 'success';
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+  autoHideDuration?: number;
+  severnity: AlertType;
+  children: React.ReactNode;
+  anchorOrigin?: { horizontal: 'center' | 'left' | 'right', vertical: 'bottom' | 'top' },
+  color?: AlertType | undefined;
+  variant?: 'filled' | 'outlined' | 'standard';
+}
+
+const Notification: React.FC<Props> = (props: Props) => (
+  <Snackbar
+    open={props.open}
+    onClose={props.onClose}
+    autoHideDuration={props.autoHideDuration}
+    anchorOrigin={props.anchorOrigin}
+  >
+    <Alert
+      onClose={props.onClose}
+      severity={props.severnity}
+      color={props.color}
+      variant={props.variant}
+    >
+      {props.children}
+    </Alert>
+  </Snackbar>
+);
+
+Notification.defaultProps = {
+  autoHideDuration: 3000,
+  anchorOrigin: { vertical: 'bottom', horizontal: 'center' },
+  color: undefined,
+  variant: 'standard',
+};
+
+export default Notification;

--- a/hosting/src/components/Notification.tsx
+++ b/hosting/src/components/Notification.tsx
@@ -7,7 +7,7 @@ type AlertType = 'error' | 'warning' | 'info' | 'success';
 interface Props {
   open: boolean;
   onClose: () => void;
-  autoHideDuration?: number;
+  autoHideDuration?: number | null;
   severnity: AlertType;
   children: React.ReactNode;
   anchorOrigin?: { horizontal: 'center' | 'left' | 'right', vertical: 'bottom' | 'top' },
@@ -34,7 +34,7 @@ const Notification: React.FC<Props> = (props: Props) => (
 );
 
 Notification.defaultProps = {
-  autoHideDuration: 3000,
+  autoHideDuration: null,
   anchorOrigin: { vertical: 'bottom', horizontal: 'center' },
   color: undefined,
   variant: 'standard',

--- a/hosting/src/pages/Room.tsx
+++ b/hosting/src/pages/Room.tsx
@@ -6,6 +6,7 @@ import NameInput from '../components/NameInput';
 import Editor from '../components/Editor';
 import Problem from '../components/Problem';
 import Users from '../components/Users';
+import Notification from '../components/Notification';
 
 import { realtimeDB, auth } from '../utils/firebase';
 import { Room, RoundState } from '../types/types';
@@ -25,6 +26,7 @@ interface State {
   room?: Room
   id: string
   user?: firebase.User
+  loginAlert: boolean
 }
 
 class RoomComponent extends React.Component<Props, State> {
@@ -32,6 +34,7 @@ class RoomComponent extends React.Component<Props, State> {
     super(props);
     this.state = {
       id: props.match.params.id,
+      loginAlert: false,
     };
 
     this.onCodeChange = this.onCodeChange.bind(this);
@@ -58,9 +61,7 @@ class RoomComponent extends React.Component<Props, State> {
 
   async onNameInput(name: string):Promise<void> {
     await this.login().catch(() => {
-      // TODO: #39
-      // eslint-disable-next-line no-alert
-      alert('ログインできませんでした。もう一度試してください。');
+      this.setState({ loginAlert: true });
     });
 
     const docRef = realtimeDB.ref(`room/${this.state.id}`);
@@ -145,6 +146,13 @@ class RoomComponent extends React.Component<Props, State> {
         <section className={classes.users}>
           <Users users={this.state.room?.users} />
         </section>
+        <Notification
+          open={this.state.loginAlert}
+          onClose={() => this.setState({ loginAlert: false })}
+          severnity="error"
+        >
+          ログインできませんでした。もう一度試してください。
+        </Notification>
       </div>
     );
   }

--- a/hosting/src/pages/Room.tsx
+++ b/hosting/src/pages/Room.tsx
@@ -150,6 +150,7 @@ class RoomComponent extends React.Component<Props, State> {
           open={this.state.loginAlert}
           onClose={() => this.setState({ loginAlert: false })}
           severnity="error"
+          variant="filled"
         >
           ログインできませんでした。もう一度試してください。
         </Notification>


### PR DESCRIPTION
closes #39 

## why 

ログインエラーのアラートを`alert`で実装していた．
ESLintにも怒られてたし，UXもあまり良くないのでは？という感じ

## what

- Snackbar/Alertのラッパを作った(`Notification.tsx`)
- `Notification`を使ってアラートを表示させるようにした