### PR TITLE
🖊 Fix stage name dev to development

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -2,7 +2,7 @@
 
 バックエンドは[Cloud Functions for Firebase](https://firebase.google.com/docs/functions?hl=ja)を用いる。
 
-各APIのエンドポイントは`/api/:stage/`というURLから始まる。`stage`は`prodction`/`staging`/`dev`が入り、ステージを分岐する。
+各APIのエンドポイントは`/api/:stage/`というURLから始まる。`stage`は`prodction`/`staging`/`development`が入り、ステージを分岐する。
 
 なお、`stage`が、上記のいずれでもなかった場合は
 

--- a/docs/database.md
+++ b/docs/database.md
@@ -19,7 +19,7 @@ Realtime Databaseはドキュメント指向なNoSQLのデータベースであ�
 
 ### `/{stage}/rooms/{roomId}`: `Room`
 
-- `stage`には`production`/`staging`/`dev`をとり、ステージを分割する。
+- `stage`には`production`/`staging`/`development`をとり、ステージを分割する。
 - `roomId`ではRealtime Databaseから自動で割り当てられたユニークなIDを利用する。
 
 ```typescript

--- a/hosting/package.json
+++ b/hosting/package.json
@@ -25,7 +25,7 @@
     "typescript": "^3.7.5"
   },
   "scripts": {
-    "start": "cross-env REACT_APP_STAGE=dev react-scripts start",
+    "start": "cross-env REACT_APP_STAGE=development react-scripts start",
     "build": "cross-env REACT_APP_STAGE=production react-scripts build",
     "build:staging": "cross-env REACT_APP_STAGE=staging react-scripts build",
     "test": "react-scripts test",


### PR DESCRIPTION
closes #98 

## why

`hosting/package.json`と`functions/handler.ts`で書いてることが違った

## what

`dev`になっていたところを`development`にした
長いけど丁寧でいいと思います